### PR TITLE
Update __main__.py

### DIFF
--- a/stitching/__main__.py
+++ b/stitching/__main__.py
@@ -10,7 +10,7 @@ import javabridge.jutil
 import numpy
 import numpy.random
 import skimage.io
-import skimage.util.montage
+from skimage.util import montage
 
 
 @click.command()


### PR DESCRIPTION
This import statement causes errors with current versions of skimage, see the [forum](https://forum.image.sc/t/problem-with-creating-tiff-file-montages-from-amnis-cif-file-for-cellprofiler/21528/4?u=bcimini).

@minh-doan 